### PR TITLE
Bug fix: casting badge number into integer doesn't work

### DIFF
--- a/lib/AnyEvent/APNS.pm
+++ b/lib/AnyEvent/APNS.pm
@@ -94,6 +94,11 @@ sub send {
     my $self = shift;
     my ($token, $payload, $expiry) = @_;
 
+    # Apple Push Notification Service refuses string values as badge number
+    if ($payload->{aps}{badge} && looks_like_number($payload->{aps}{badge})) {
+        $payload->{aps}{badge} += 0;
+    }
+
     my $json = encode_utf8( $self->json_driver->encode($payload) );
 
     # http://developer.apple.com/library/ios/#DOCUMENTATION/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingWIthAPS/CommunicatingWIthAPS.html
@@ -111,11 +116,6 @@ sub send {
     $h->push_write( pack('N', $expiry) );
     $h->push_write( pack('n', bytes::length($token)) ); # token length
     $h->push_write( $token );                           # device token
-
-    # Apple Push Notification Service refuses string values as badge number
-    if ($payload->{aps}{badge} && looks_like_number($payload->{aps}{badge})) {
-        $payload->{aps}{badge} += 0;
-    }
 
     # The maximum size allowed for a notification payload is 256 bytes;
     # Apple Push Notification Service refuses any notification that exceeds this limit.

--- a/t/05_badge.t
+++ b/t/05_badge.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::TCP;
+use AnyEvent::APNS;
+use AnyEvent::Socket;
+
+my $port = empty_port;
+
+my $apns; $apns = AnyEvent::APNS->new(
+    debug_port  => $port,
+    certificate => 'dummy',
+    private_key => 'dummy',
+    on_error    => sub { die $! },
+    on_connect  => sub {
+        $apns->send('d' x 32 => { aps => { badge => "110" } });
+    },
+);
+
+my $cv = AnyEvent->condvar;
+
+tcp_server undef, $port, sub {
+    my ($fh) = @_
+        or die $!;
+
+    my $handle; $handle = AnyEvent::Handle->new(
+        fh       => $fh,
+        on_eof   => sub {},
+        on_error => sub {
+            die $!;
+            undef $handle;
+        },
+        on_read => sub {},
+    );
+
+    $handle->push_read( chunk => 43, sub {}); # all before payload
+
+    $handle->push_read( chunk => 2, sub {
+        my $payload_length = unpack('n', $_[1]);
+
+        $handle->push_read( chunk => $payload_length, sub {
+            my $payload = $_[1];
+			is($payload, '{"aps":{"badge":110}}');
+			$cv->send;
+        });
+
+        undef $apns;
+    });
+};
+
+$apns->connect;
+
+$cv->recv;
+
+done_testing;


### PR DESCRIPTION
The following line is almost unuseful because this will be done after encoding payload to JSON.

> $payload->{aps}{badge} += 0

So, bring this to the first of the method (before encoding)
