### PR TITLE
Changed json payload max length to 2048 bytes.

### DIFF
--- a/lib/AnyEvent/APNS.pm
+++ b/lib/AnyEvent/APNS.pm
@@ -117,9 +117,9 @@ sub send {
         $payload->{aps}{badge} += 0;
     }
 
-    # The maximum size allowed for a notification payload is 256 bytes;
+    # The maximum size allowed for a notification payload is 2048 bytes;
     # Apple Push Notification Service refuses any notification that exceeds this limit.
-    if ( (my $exceeded = bytes::length($json) - 256) > 0 ) {
+    if ( (my $exceeded = bytes::length($json) - 2048) > 0 ) {
         if (ref $payload->{aps}{alert} eq 'HASH') {
             $payload->{aps}{alert}{body} =
                 $self->_trim_utf8($payload->{aps}{alert}{body}, $exceeded);

--- a/t/02_trim.t
+++ b/t/02_trim.t
@@ -13,8 +13,8 @@ use AnyEvent::Socket;
 my $port = empty_port;
 
 my $payloads = [
-    { aps => { alert => 'こんにちは'x100, } },
-    { aps => { alert => { body => 'こんにちは'x100, } } },
+    { aps => { alert => 'こんにちは'x200, } },
+    { aps => { alert => { body => 'こんにちは'x200, } } },
 ];
 
 for my $payload (@$payloads) {
@@ -76,7 +76,7 @@ for my $payload (@$payloads) {
 
         $handle->push_read( chunk => 2, sub {
             my $payload_length = unpack('n', $_[1]);
-            like($payload_length, qr/^25[0-6]$/, 'truncate $payload->{alert} ok');
+            like($payload_length, qr/^204[0-8]$/, 'truncate $payload->{alert} ok');
 
             $handle->push_read( chunk => $payload_length, sub {
                 is(length $_[1], $payload_length, 'payload length ok');


### PR DESCRIPTION
@typester 
Apple changed json payload max length to 2048 bytes.
https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html
